### PR TITLE
Update reference URL in example comment

### DIFF
--- a/examples/Test/Test.ino
+++ b/examples/Test/Test.ino
@@ -1,7 +1,7 @@
 /*
   MKR Motor Shield Test sketch
   This sketch demonstrates some APIs exposed by the MKR Motor Shield library.
-  For the complete list, visit the reference page on https://www.arduino.cc/en/Reference/MKRMotorShield
+  For the complete list, visit the reference page on https://www.arduino.cc/en/Reference/MKRMotorCarrier
   This example code is in the public domain.
 */
 


### PR DESCRIPTION
The previous URL gives a 404 error.