### PR TITLE
Update sketch paths in "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -94,9 +94,7 @@ jobs:
             libraries: |
               -
             sketch-paths: |
-              - examples/Motor_test
-              - examples/Motor_test_encoder
-              - examples/Servo_test
+              - examples/MKR
 
     steps:
       - name: Checkout repository
@@ -114,7 +112,6 @@ jobs:
             ${{ matrix.libraries }}
           sketch-paths: |
             - examples/Flasher
-            - examples/Test
             ${{ matrix.sketch-paths }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}


### PR DESCRIPTION
Due to the library having examples specific to the MKR and Nano boards, the CI workflow must be configured to compile only the examples of that board. The examples were moved (https://github.com/arduino-libraries/ArduinoMotorCarrier/pull/34) after the time the workflow was written without updating the workflow, resulting in spurious workflow run failures as opposed to the legitimate failures caused by this library's various bugs.