### PR TITLE
Remove Portenta from "Compile Examples" workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -71,14 +71,6 @@ jobs:
             platforms: |
               - name: arduino:samd
             type: mkr
-          - fqbn: arduino:mbed_portenta:envie_m4
-            platforms: |
-              - name: arduino:mbed_portenta
-            type: mkr
-          - fqbn: arduino:mbed_portenta:envie_m7
-            platforms: |
-              - name: arduino:mbed_portenta
-            type: mkr
 
         # make board type-specific customizations to the matrix jobs
         include:


### PR DESCRIPTION
The library is not intended to support the Portenta H7 board, so there is no need to check whether the examples will compile for it.