### PR TITLE
Correct library reference URL in metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Arduino <info@arduino.cc>
 sentence=Allows use of the Arduino Motor Carrier 
 paragraph=(Nano and MKR version)
 category=Signal Input/Output
-url=https://www.arduino.cc/reference/en/libraries/ArduinoMotorCarrier/
+url=https://www.arduino.cc/reference/en/libraries/arduinomotorcarrier/
 architectures=samd
 includes=ArduinoMotorCarrier.h


### PR DESCRIPTION
The library.properties `url` field provides a location for users to find information about the library. The automatically generated library reference pages are accessed via a URL based on the library `name` value converted to all lower case. Use of the real library name with upper case letters results in a 404.