### PR TITLE
[AEK-328] Remove interrupt statement in examples

### DIFF
--- a/examples/Nano/DCMotorTest/DCMotorTest.ino
+++ b/examples/Nano/DCMotorTest/DCMotorTest.ino
@@ -1,5 +1,4 @@
 #include <ArduinoMotorCarrier.h>
-#define INTERRUPT_PIN 6
 
 //Variable to store the battery voltage
 static int batteryVoltage;

--- a/examples/Nano/EncoderTest/EncoderTest.ino
+++ b/examples/Nano/EncoderTest/EncoderTest.ino
@@ -1,5 +1,4 @@
 #include <ArduinoMotorCarrier.h>
-#define INTERRUPT_PIN 6
 
 //Variable to store the battery voltage
 static int batteryVoltage;

--- a/examples/Nano/PID_Position_test/PID_Position_test.ino
+++ b/examples/Nano/PID_Position_test/PID_Position_test.ino
@@ -1,6 +1,5 @@
 #include <MKRMotorCarrier_PID_test.h>
 //#include <MKRMotorCarrier.h>
-#define INTERRUPT_PIN 6
 
 //Variable to store the battery voltage
 static int batteryVoltage;

--- a/examples/Nano/ServoTest/ServoTest.ino
+++ b/examples/Nano/ServoTest/ServoTest.ino
@@ -2,7 +2,6 @@
 #include <ArduinoMotorCarrier.h>
 //#include <MKRMotorCarrier.h>
 //#include <MKRMotorCarrier_REV2.h>
-#define INTERRUPT_PIN 6
 
 
 void setup()


### PR DESCRIPTION
Following the [comment](https://github.com/arduino/docs.arduino.cc/pull/781#discussion_r760203486) by @per1234 , I have removed the `interrupt` statements at the beginning of the sketches.

> No purpose at all. It only serves to confuse the users.
>
> It must be removed from the library examples as well.